### PR TITLE
docs: improve equation formatting in whitepaper

### DIFF
--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -12,10 +12,17 @@ We let π become an adaptive field πₐ that relaxes to the Euclidean π via a 
 steering in a near regime. In “far” starts we update with damping-only; in “near” we include gradient feedback:
 
 - **Far regime:** α = 0, update
-  $$\pi_a \leftarrow \pi_a - \mu(\pi_a - \pi)$$
+
+  \[
+  \pi_a \leftarrow \pi_a - \mu(\pi_a - \pi)
+  \]
+
   with angle-reduced trig to maintain numerical stability for extreme initial values.
 - **Near regime:** re-enable gradient:
-  $$\pi_a \leftarrow \pi_a - \alpha \, e \, \frac{\partial P}{\partial \pi_a} - \mu(\pi_a - \pi)$$
+
+  \[
+  \pi_a \leftarrow \pi_a - \alpha \, e \, \frac{\partial P}{\partial \pi_a} - \mu(\pi_a - \pi)
+  \]
 
 CMA encoding uses πₐ consistently in curvature/angle parameterizations so that *symbol boundaries* remain
 stable while allowing adaptive geometry.
@@ -41,7 +48,11 @@ combined information—hence **lossless-size** composition under the wedge const
 ## 4. ARP/MD-ARP Stabilization
 
 We modulate glyph strengths \( G_i \) using ARP-style dynamics:
-\[ \frac{dG_i}{dt} = \alpha |I_i| - \mu G_i \]
+
+\[
+\frac{dG_i}{dt} = \alpha |I_i| - \mu G_i
+\]
+
 where \( I_i \) is a local evidence/current for glyph \( i \) during decoding. This suppresses noise and yields
 consistent symbol recovery across scales.
 


### PR DESCRIPTION
## Summary
- format adaptive pi update equations as standalone math blocks for clarity
- render ARP dynamics with block LaTeX

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'curve_memory')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0 due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c4653b0638832fa2df8c5440046539