### PR TITLE
Format markdown equations with LaTeX

### DIFF
--- a/docs/HYPERBOLIC_GEOMETRY_IMPLEMENTATION.md
+++ b/docs/HYPERBOLIC_GEOMETRY_IMPLEMENTATION.md
@@ -4,18 +4,18 @@
 
 Successfully implemented a **robust, production-quality** hyperbolic geometry system for AdaptiveCAD that handles all numerical edge cases and instabilities in the fundamental adaptive pi formula:
 
-```
-π_a/π = (κ * sinh(r/κ)) / r
-```
+$$
+\frac{\pi_a}{\pi} = \frac{\kappa \cdot \sinh(r/\kappa)}{r}
+$$
 
 ## Key Improvements
 
 ### 🔧 **Numerical Stability Fixes**
 
-1. **Zero Division Protection**: Handles `r ≈ 0` and `κ ≈ 0` gracefully
-2. **Overflow Prevention**: Manages large `r/κ` ratios without overflow/underflow
-3. **Taylor Expansion**: Uses precise series expansion for small `|r/κ|` values
-4. **Fallback Strategy**: Returns Euclidean limit (1.0) for unstable cases
+1. **Zero Division Protection**: Handles $r \approx 0$ and $\kappa \approx 0$ gracefully
+2. **Overflow Prevention**: Manages large $r/\kappa$ ratios without overflow/underflow
+3. **Taylor Expansion**: Uses precise series expansion for small $|r/\kappa|$ values
+4. **Fallback Strategy**: Returns Euclidean limit $1.0$ for unstable cases
 
 ### 📁 **Files Modified/Created**
 
@@ -123,7 +123,7 @@ metrics = adaptive_pi_metrics(1.0, 1.0)
 
 #### **Before the Fix**
 - Import used **old, unstable** `pi_a_over_pi` from `nd_math.py`
-- **Different formula**: Used `sqrt(|κ|) * r` approach instead of direct `r/κ`
+- **Different formula**: Used $\sqrt{|\kappa|} \cdot r$ approach instead of direct $r/\kappa$
 - **No overflow protection**: Could fail on large geometric models
 - **No parameter validation**: Silent failures or incorrect transformations
 - **Transformation was disabled**: Code had "TEMP: Bypass pi_a_over_pi transformation"
@@ -182,9 +182,9 @@ from ..nd_math import stable_pi_a_over_pi  # Legacy fallback
 
 The implementation correctly handles the fundamental adaptive pi relationship:
 
-- **Euclidean case**: `κ → 0` or `r → 0` gives `π_a/π → 1`
-- **Hyperbolic case**: `κ < 0` produces stable, positive ratios
-- **Spherical case**: `κ > 0` produces expected sinh-based scaling
+- **Euclidean case**: $\kappa \to 0$ or $r \to 0$ gives $\pi_a/\pi \to 1$
+- **Hyperbolic case**: $\kappa < 0$ produces stable, positive ratios
+- **Spherical case**: $\kappa > 0$ produces expected $\sinh$-based scaling
 - **Extreme cases**: Large ratios fall back to Euclidean limit for stability
 
 ## Performance Characteristics

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -11,62 +11,62 @@ obeys exterior/wedge constraints that ensure well-posed decoding and open the do
 We let π become an adaptive field πₐ that relaxes to the Euclidean π via a damping term μ and optional gradient
 steering in a near regime. In “far” starts we update with damping-only; in “near” we include gradient feedback:
 
-- **Far regime:** α = 0, update
+  - **Far regime:** α = 0, update
 
-  \[
-  \pi_a \leftarrow \pi_a - \mu(\pi_a - \pi)
-  \]
+    $$
+    \pi_a \leftarrow \pi_a - \mu(\pi_a - \pi)
+    $$
 
   with angle-reduced trig to maintain numerical stability for extreme initial values.
-- **Near regime:** re-enable gradient:
+  - **Near regime:** re-enable gradient:
 
-  \[
-  \pi_a \leftarrow \pi_a - \alpha \, e \, \frac{\partial P}{\partial \pi_a} - \mu(\pi_a - \pi)
-  \]
+    $$
+    \pi_a \leftarrow \pi_a - \alpha \, e \, \frac{\partial P}{\partial \pi_a} - \mu(\pi_a - \pi)
+    $$
 
 CMA encoding uses πₐ consistently in curvature/angle parameterizations so that *symbol boundaries* remain
 stable while allowing adaptive geometry.
 
 ## 2. Glyphs and Combinators
 
-A glyph \( g \) is a tuple \( (\mathcal{F}, \theta) \) where \( \mathcal{F} \) is a parametric family (e.g., arc,
-clothoid fragment, cubic segment, helical micro-curve) and \( \theta \) are parameters. Combinators:
+A glyph $g$ is a tuple $(\mathcal{F}, \theta)$ where $\mathcal{F}$ is a parametric family (e.g., arc,
+clothoid fragment, cubic segment, helical micro-curve) and $\theta$ are parameters. Combinators:
 
-- **Concatenate** \( g_1 \oplus g_2 \): end-frame of \( g_1 \) matches start-frame of \( g_2 \).
-- **Wedge** \( g_1 \wedge g_2 \): antisymmetric join imposing orientation/area constraints, enabling
+- **Concatenate** $g_1 \oplus g_2$: end-frame of $g_1$ matches start-frame of $g_2$.
+- **Wedge** $g_1 \wedge g_2$: antisymmetric join imposing orientation/area constraints, enabling
   *compressibility* when the exterior product nullifies redundant subspace components.
-- **Bind** \( \mathcal{B}_\lambda(g) \): weight/attention binding used in decoding; λ obeys ARP-like dynamics.
+- **Bind** $\mathcal{B}_\lambda(g)$: weight/attention binding used in decoding; λ obeys ARP-like dynamics.
 
 ## 3. Wedge-product Compressibility (Sketch)
 
-Let \( c_1, c_2 \in \Lambda^k(V) \) be k-vectors derived from local frame differentials of two glyph segments.
-Redundancy implies \( c_1 \) and \( c_2 \) have significant overlap in subspaces of \( V \).
-If \( c_1 \wedge c_2 \approx 0 \) (or lies in a low-volume subspace), we admit an *equivalence contraction*
-rule \( (g_1 \oplus g_2) \sim g^\star \) where \( g^\star \) is a single glyph whose parameters encode the
+Let $c_1, c_2 \in \Lambda^k(V)$ be k-vectors derived from local frame differentials of two glyph segments.
+Redundancy implies $c_1$ and $c_2$ have significant overlap in subspaces of $V$.
+If $c_1 \wedge c_2 \approx 0$ (or lies in a low-volume subspace), we admit an *equivalence contraction*
+rule $(g_1 \oplus g_2) \sim g^\star$ where $g^\star$ is a single glyph whose parameters encode the
 combined information—hence **lossless-size** composition under the wedge constraint.
 
 ## 4. ARP/MD-ARP Stabilization
 
-We modulate glyph strengths \( G_i \) using ARP-style dynamics:
+We modulate glyph strengths $G_i$ using ARP-style dynamics:
 
-\[
+$$
 \frac{dG_i}{dt} = \alpha |I_i| - \mu G_i
-\]
+$$
 
-where \( I_i \) is a local evidence/current for glyph \( i \) during decoding. This suppresses noise and yields
+where $I_i$ is a local evidence/current for glyph $i$ during decoding. This suppresses noise and yields
 consistent symbol recovery across scales.
 
 ## 5. Decoding
 Given a target curve (e.g., polyline or spline), we seek the minimal CMA sequence whose composed transform
-matches the curve within tolerance \(\epsilon\). We solve by alternating:
+matches the curve within tolerance $\epsilon$. We solve by alternating:
 1. **Symbol proposal** (discrete search over glyph templates / dynamic programming),
 2. **Parameter refinement** (continuous least-squares on frames),
 3. **Wedge checks** (attempt equivalence contractions),
 4. **ARP stabilization** on glyph weights.
 
 ## 6. Curve Hashes
-We define a *curve hash* \( H(c) \) as a tuple of stable invariants (integrals of κ, τ, signed areas, and
-selected wedge components). Under small deformations within admissible ranges, \( H \) remains constant, enabling
+We define a *curve hash* $H(c)$ as a tuple of stable invariants (integrals of κ, τ, signed areas, and
+selected wedge components). Under small deformations within admissible ranges, $H$ remains constant, enabling
 fast equality checks and deduplication.
 
 ## 7. Guarantees (informal)


### PR DESCRIPTION
## Summary
- Use LaTeX inline `$` and block `$$` math across docs to standardize equation presentation
- Clarify hyperbolic geometry doc with explicit adaptive π formula and math-formatted parameter notes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'curve_memory')*

------
https://chatgpt.com/codex/tasks/task_e_68c46993f6b8832fa72fd00b8b0088b6